### PR TITLE
Delete librfnm class on teardown

### DIFF
--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -25,6 +25,7 @@ SoapyRFNM::SoapyRFNM(const SoapySDR::Kwargs& args) {
 
 SoapyRFNM::~SoapyRFNM() {
     spdlog::info("RFNMDevice::~RFNMDevice()");
+    delete lrfnm;
 }
 
 


### PR DESCRIPTION
Actually clean up and release interfaces