### PR TITLE
Cleanup, bug fixes, and additional functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,11 @@ add_library(soapy-rfnm SHARED)
 
 target_link_libraries(soapy-rfnm PRIVATE librfnm)
 
+target_compile_options(soapy-rfnm PRIVATE -Wall -Wextra -Wno-unused-parameter)
+
 # sources
 target_sources(soapy-rfnm PRIVATE
-  
   "src/soapy_rfnm.cpp"
-  #"src/librfnm.cpp" "src/librfnm.h" "src/librfnm_api.h"
 )
 
 # definitions

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -95,40 +95,34 @@ int SoapyRFNM::deactivateStream(SoapySDR::Stream* stream, const int flags0, cons
     return 0;
 }
 
-void SoapyRFNM::setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args)
-{
+void SoapyRFNM::setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args) {
     lrfnm->s->rx.ch[0].freq = frequency;
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
 }
 
-void SoapyRFNM::setGain(const int direction, const size_t channel, const double value)
-{
+void SoapyRFNM::setGain(const int direction, const size_t channel, const double value) {
     lrfnm->s->rx.ch[0].gain = value;
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
 }
 
-SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel) const
-{
+SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel) const {
     return SoapySDR::Range(-100, 100);
 }
 
-void SoapyRFNM::setBandwidth(const int direction, const size_t channel, const double bw)
-{
+void SoapyRFNM::setBandwidth(const int direction, const size_t channel, const double bw) {
     if (bw == 0.0) return; //special ignore value
 
     lrfnm->s->rx.ch[0].rfic_lpf_bw = bw / 1e6;
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
 }
 
-SoapySDR::RangeList SoapyRFNM::getBandwidthRange(const int direction, const size_t channel) const
-{
+SoapySDR::RangeList SoapyRFNM::getBandwidthRange(const int direction, const size_t channel) const {
     SoapySDR::RangeList bws;
     bws.push_back(SoapySDR::Range(1e6, 100e6));
     return bws;
 }
 
-std::vector<std::string> SoapyRFNM::listAntennas(const int direction, const size_t channel) const
-{
+std::vector<std::string> SoapyRFNM::listAntennas(const int direction, const size_t channel) const {
     std::vector<std::string> ants;
     if (direction == SOAPY_SDR_RX) {
         for (int a = 0; a < 10; a++) {
@@ -145,8 +139,7 @@ std::vector<std::string> SoapyRFNM::listAntennas(const int direction, const size
     return ants;
 }
 
-void SoapyRFNM::setAntenna(const int direction, const size_t channel, const std::string& name)
-{
+void SoapyRFNM::setAntenna(const int direction, const size_t channel, const std::string& name) {
     lrfnm->s->rx.ch[0].path = librfnm::string_to_rf_path(name);
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
 }
@@ -272,15 +265,13 @@ keep_waiting:
     return read_elems;
 }
 
-SoapySDR::Device* rfnm_device_create(const SoapySDR::Kwargs& args)
-{
+SoapySDR::Device* rfnm_device_create(const SoapySDR::Kwargs& args) {
     spdlog::info("rfnm_device_create()");
 
     return new SoapyRFNM(args);
 }
 
 SoapySDR::KwargsList rfnm_device_find(const SoapySDR::Kwargs& args) {
-
     std::vector<struct rfnm_dev_hwinfo> hwlist = librfnm::find(LIBRFNM_TRANSPORT_USB);
     std::vector< SoapySDR::Kwargs> ret;
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -24,6 +24,20 @@ SoapyRFNM::SoapyRFNM(const SoapySDR::Kwargs& args) {
     memset(rxbuf, 0, sizeof(rxbuf));
     //memset(txbuf, 0, sizeof(rxbuf));
     memset(&partial_rx_buf, 0, sizeof(struct rfnm_soapy_partial_buf));
+
+    // sane defaults
+    lrfnm->s->rx.ch[0].freq = RFNM_MHZ_TO_HZ(2450);
+    lrfnm->s->rx.ch[0].path = lrfnm->s->rx.ch[0].path_preferred;
+    lrfnm->s->rx.ch[0].samp_freq_div_n = 1;
+
+    //s->rx.ch[1].freq = RFNM_MHZ_TO_HZ(2450);
+    //s->rx.ch[1].path = s->rx.ch[1].path_preferred;
+    //s->tx.ch[1].samp_freq_div_n = 2;
+
+    //s->tx.ch[0].freq = RFNM_MHZ_TO_HZ(2450);
+    //s->tx.ch[0].path = s->tx.ch[0].path_preferred;
+    //s->tx.ch[0].samp_freq_div_n = 2;
+
 }
 
 SoapyRFNM::~SoapyRFNM() {
@@ -191,19 +205,8 @@ void SoapyRFNM::setAntenna(const int direction, const size_t channel, const std:
 SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string& format,
         const std::vector<size_t>& channels, const SoapySDR::Kwargs& args) {
     lrfnm->s->rx.ch[0].enable = RFNM_CH_ON;
-    lrfnm->s->rx.ch[0].freq = RFNM_MHZ_TO_HZ(2450);
-    lrfnm->s->rx.ch[0].path = lrfnm->s->rx.ch[0].path_preferred;
-    lrfnm->s->rx.ch[0].samp_freq_div_n = 1;
-
     //s->rx.ch[1].enable = RFNM_CH_ON;
-    //s->rx.ch[1].freq = RFNM_MHZ_TO_HZ(2450);
-    //s->rx.ch[1].path = s->rx.ch[1].path_preferred;
-    //s->tx.ch[1].samp_freq_div_n = 2;
-
     //s->tx.ch[0].enable = RFNM_CH_ON;
-    //s->tx.ch[0].freq = RFNM_MHZ_TO_HZ(2450);
-    //s->tx.ch[0].path = s->tx.ch[0].path_preferred;
-    //s->tx.ch[0].samp_freq_div_n = 2;
 
     if (lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/)) {
         throw std::runtime_error("setupStream error configuring RFNM");

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -212,16 +212,16 @@ int SoapyRFNM::readStream(SoapySDR::Stream* stream, void* const* buffs, const si
         long long int& timeNs, const long timeoutUs) {
     double m_readstream_time_diff;
 
-    int bytes_per_ele = lrfnm->s->transport_status.rx_stream_format;
+    size_t bytes_per_ele = lrfnm->s->transport_status.rx_stream_format;
 
     std::chrono::time_point<std::chrono::system_clock> m_readstream_start_time = std::chrono::system_clock::now();
 
     struct librfnm_rx_buf* lrxbuf;
-    int read_elems = 0;
+    size_t read_elems = 0;
 
 keep_waiting:
     if (partial_rx_buf.left) {
-        int can_write_bytes = numElems * bytes_per_ele;
+        size_t can_write_bytes = numElems * bytes_per_ele;
         if (can_write_bytes > partial_rx_buf.left) {
             can_write_bytes = partial_rx_buf.left;
         }
@@ -234,8 +234,8 @@ keep_waiting:
     }
 
     while (read_elems < numElems && !lrfnm->rx_dqbuf(&lrxbuf, LIBRFNM_CH0 /* | LIBRFNM_CH1*/, 0)) {
-        int overflowing_by_elems = 0;
-        int can_copy_bytes = outbufsize;
+        size_t overflowing_by_elems = 0;
+        size_t can_copy_bytes = outbufsize;
 
         if ((read_elems + (outbufsize / bytes_per_ele)) > numElems) {
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -8,7 +8,6 @@
 
 
 SoapyRFNM::SoapyRFNM(const SoapySDR::Kwargs& args) {
-
     spdlog::info("RFNMDevice::RFNMDevice()");
 
     if (args.count("serial") != 0) {
@@ -26,7 +25,6 @@ SoapyRFNM::SoapyRFNM(const SoapySDR::Kwargs& args) {
 }
 
 SoapyRFNM::~SoapyRFNM() {
-
     if (partial_rx_buf.buf) {
         free(partial_rx_buf.buf);
     }
@@ -72,7 +70,6 @@ std::vector<double> SoapyRFNM::listSampleRates(const int direction, const size_t
 }
 
 std::string SoapyRFNM::getNativeStreamFormat(const int direction, const size_t /*channel*/, double& fullScale) const {
-
     fullScale = 32768;
     return SOAPY_SDR_CS16;
 }
@@ -85,16 +82,9 @@ std::vector<std::string> SoapyRFNM::getStreamFormats(const int direction, const 
     return formats;
 }
 
-
-
-
-
-
-
 int SoapyRFNM::activateStream(SoapySDR::Stream* stream, const int flags, const long long timeNs,
-    const size_t numElems) {
+        const size_t numElems) {
     spdlog::info("RFNMDevice::activateStream()");
-
 
     return 0;
 }
@@ -102,10 +92,8 @@ int SoapyRFNM::activateStream(SoapySDR::Stream* stream, const int flags, const l
 int SoapyRFNM::deactivateStream(SoapySDR::Stream* stream, const int flags0, const long long int timeNs) {
     spdlog::info("RFNMDevice::deactivateStream()");
 
-
     return 0;
 }
-
 
 void SoapyRFNM::setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args)
 {
@@ -113,8 +101,6 @@ void SoapyRFNM::setFrequency(int direction, size_t channel, double frequency, co
 
     lrfnm->s->rx.ch[0].freq = frequency;
     fail = lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
-
-
 }
 
 void SoapyRFNM::setGain(const int direction, const size_t channel, const double value)
@@ -138,7 +124,6 @@ void SoapyRFNM::setBandwidth(const int direction, const size_t channel, const do
 
     lrfnm->s->rx.ch[0].rfic_lpf_bw = bw / 1e6;
     fail = lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
-
 }
 
 SoapySDR::RangeList SoapyRFNM::getBandwidthRange(const int direction, const size_t channel) const
@@ -161,7 +146,7 @@ std::vector<std::string> SoapyRFNM::listAntennas(const int direction, const size
     }
     else if (direction == SOAPY_SDR_TX) {
         //   ants.push_back("TXH");
-       //    ants.push_back("TXW");
+        //    ants.push_back("TXW");
     }
     return ants;
 }
@@ -174,20 +159,10 @@ void SoapyRFNM::setAntenna(const int direction, const size_t channel, const std:
 
     lrfnm->s->rx.ch[0].path = librfnm::string_to_rf_path(name);
     fail = lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
-
-
 }
 
-
-
-
-
-
-SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string& format, const std::vector<size_t>& channels, const SoapySDR::Kwargs& args) {
-
-
-
-
+SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string& format,
+        const std::vector<size_t>& channels, const SoapySDR::Kwargs& args) {
     lrfnm->s->rx.ch[0].enable = RFNM_CH_ON;
     lrfnm->s->rx.ch[0].freq = RFNM_MHZ_TO_HZ(2450);
     lrfnm->s->rx.ch[0].path = lrfnm->s->rx.ch[0].path_preferred;
@@ -205,7 +180,6 @@ SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string&
 
     volatile rfnm_api_failcode fail;
     fail = lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
-
 
     if (!format.compare(SOAPY_SDR_CF32)) {
         //m_outbuf.format = format;
@@ -226,9 +200,7 @@ SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string&
         throw std::runtime_error("setupStream invalid format " + format);
     }
 
-
     //lrfnm->tx_stream(LIBRFNM_STREAM_FORMAT_CS16, &inbufsize);
-
 
     std::queue<struct librfnm_tx_buf*> ltxqueue;
     //std::queue<struct librfnm_rx_buf*> lrxqueue;
@@ -245,8 +217,6 @@ SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string&
 
     spdlog::info("outbufsize {} inbufsize {} ", outbufsize, inbufsize);
 
-
-
     return (SoapySDR::Stream*)this;
 }
 
@@ -254,11 +224,8 @@ void SoapyRFNM::closeStream(SoapySDR::Stream* stream) {
     spdlog::info("RFNMDevice::closeStream() -> Closing stream");
 }
 
-
-
-
 int SoapyRFNM::readStream(SoapySDR::Stream* stream, void* const* buffs, const size_t numElems, int& flags,
-    long long int& timeNs, const long timeoutUs) {
+        long long int& timeNs, const long timeoutUs) {
 
     long total_data, data_diff;
     double time_diff, m_readstream_time_diff;
@@ -318,20 +285,12 @@ keep_waiting:
     return read_elems;
 }
 
-
-
-
 SoapySDR::Device* rfnm_device_create(const SoapySDR::Kwargs& args)
 {
     spdlog::info("rfnm_device_create()");
 
-
-
     return new SoapyRFNM(args);
 }
-
-
-
 
 SoapySDR::KwargsList rfnm_device_find(const SoapySDR::Kwargs& args) {
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -21,6 +21,8 @@ SoapyRFNM::SoapyRFNM(const SoapySDR::Kwargs& args) {
         throw std::runtime_error("Couldn't open the RFNM USB device handle");
     }
 
+    memset(rxbuf, 0, sizeof(rxbuf));
+    //memset(txbuf, 0, sizeof(rxbuf));
     memset(&partial_rx_buf, 0, sizeof(struct rfnm_soapy_partial_buf));
 }
 
@@ -29,7 +31,7 @@ SoapyRFNM::~SoapyRFNM() {
         free(partial_rx_buf.buf);
     }
 
-    for (int i = 0; i < SOAPY_RFNM_BUFCNF; i++) {
+    for (int i = 0; i < SOAPY_RFNM_BUFCNT; i++) {
         if (rxbuf[i].buf) {
             free(rxbuf[i].buf);
         }
@@ -219,7 +221,7 @@ SoapySDR::Stream* SoapyRFNM::setupStream(const int direction, const std::string&
     //std::queue<struct librfnm_rx_buf*> lrxqueue;
 
     partial_rx_buf.buf = (uint8_t*)malloc(outbufsize);
-    for (int i = 0; i < SOAPY_RFNM_BUFCNF; i++) {
+    for (int i = 0; i < SOAPY_RFNM_BUFCNT; i++) {
         rxbuf[i].buf = (uint8_t*)malloc(outbufsize);
         lrfnm->rx_qbuf(&rxbuf[i]);
         //txbuf[i].buf = rxbuf[i].buf;

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -69,6 +69,10 @@ std::vector<double> SoapyRFNM::listSampleRates(const int direction, const size_t
     return rates;
 }
 
+double SoapyRFNM::getSampleRate(const int direction, const size_t channel) const {
+    return lrfnm->s->hwinfo.clock.dcs_clk;
+}
+
 std::string SoapyRFNM::getNativeStreamFormat(const int direction, const size_t /*channel*/, double& fullScale) const {
     fullScale = 32768;
     return SOAPY_SDR_CS16;
@@ -95,9 +99,26 @@ int SoapyRFNM::deactivateStream(SoapySDR::Stream* stream, const int flags0, cons
     return 0;
 }
 
+SoapySDR::RangeList SoapyRFNM::getFrequencyRange(const int direction, const size_t channel, const std::string &name) const {
+    SoapySDR::RangeList results;
+
+    // assume Lime for now, let's say 30M to 3.8G
+    results.push_back(SoapySDR::Range(30e6, 3.8e9));
+
+    return results;
+}
+
+double SoapyRFNM::getFrequency(const int direction, const size_t channel, const std::string &name) const {
+    return lrfnm->s->rx.ch[0].freq;
+}
+
 void SoapyRFNM::setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args) {
     lrfnm->s->rx.ch[0].freq = frequency;
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
+}
+
+double SoapyRFNM::getGain(const int direction, const size_t channel, const std::string &name) const {
+    return lrfnm->s->rx.ch[0].gain;
 }
 
 void SoapyRFNM::setGain(const int direction, const size_t channel, const double value) {
@@ -107,6 +128,10 @@ void SoapyRFNM::setGain(const int direction, const size_t channel, const double 
 
 SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel) const {
     return SoapySDR::Range(-100, 100);
+}
+
+double SoapyRFNM::getBandwidth(const int direction, const size_t channel) const {
+    return lrfnm->s->rx.ch[0].rfic_lpf_bw * 1e6;
 }
 
 void SoapyRFNM::setBandwidth(const int direction, const size_t channel, const double bw) {
@@ -137,6 +162,10 @@ std::vector<std::string> SoapyRFNM::listAntennas(const int direction, const size
         //    ants.push_back("TXW");
     }
     return ants;
+}
+
+std::string SoapyRFNM::getAntenna(const int direction, const size_t channel) const {
+    return librfnm::rf_path_to_string(lrfnm->s->rx.ch[0].path);
 }
 
 void SoapyRFNM::setAntenna(const int direction, const size_t channel, const std::string& name) {

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -123,10 +123,7 @@ std::vector<std::string> SoapyRFNM::listFrequencies(const int direction, const s
 
 SoapySDR::RangeList SoapyRFNM::getFrequencyRange(const int direction, const size_t channel, const std::string &name) const {
     SoapySDR::RangeList results;
-
-    // assume Lime for now, let's say 30M to 3.8G
-    results.push_back(SoapySDR::Range(30e6, 3.8e9));
-
+    results.push_back(SoapySDR::Range(lrfnm->s->rx.ch[0].freq_min, lrfnm->s->rx.ch[0].freq_max));
     return results;
 }
 
@@ -156,6 +153,7 @@ void SoapyRFNM::setGain(const int direction, const size_t channel, const std::st
 }
 
 SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel, const std::string &name) const {
+    //return SoapySDR::Range(lrfnm->s->rx.ch[0].gain_range.min, lrfnm->s->rx.ch[0].gain_range.max);
     return SoapySDR::Range(-100, 100);
 }
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -27,6 +27,9 @@ SoapyRFNM::SoapyRFNM(const SoapySDR::Kwargs& args) {
 }
 
 SoapyRFNM::~SoapyRFNM() {
+    spdlog::info("RFNMDevice::~RFNMDevice()");
+    delete lrfnm;
+
     if (partial_rx_buf.buf) {
         free(partial_rx_buf.buf);
     }
@@ -36,9 +39,6 @@ SoapyRFNM::~SoapyRFNM() {
             free(rxbuf[i].buf);
         }
     }
-
-    spdlog::info("RFNMDevice::~RFNMDevice()");
-    delete lrfnm;
 }
 
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -101,6 +101,12 @@ int SoapyRFNM::deactivateStream(SoapySDR::Stream* stream, const int flags0, cons
     return 0;
 }
 
+std::vector<std::string> SoapyRFNM::listFrequencies(const int direction, const size_t channel) const {
+    std::vector<std::string> names;
+    names.push_back("RF");
+    return names;
+}
+
 SoapySDR::RangeList SoapyRFNM::getFrequencyRange(const int direction, const size_t channel, const std::string &name) const {
     SoapySDR::RangeList results;
 
@@ -114,21 +120,28 @@ double SoapyRFNM::getFrequency(const int direction, const size_t channel, const 
     return lrfnm->s->rx.ch[0].freq;
 }
 
-void SoapyRFNM::setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args) {
+void SoapyRFNM::setFrequency(const int direction, const size_t channel, const std::string &name,
+        const double frequency, const SoapySDR::Kwargs& args) {
     lrfnm->s->rx.ch[0].freq = frequency;
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
+}
+
+std::vector<std::string> SoapyRFNM::listGains(const int direction, const size_t channel) const {
+    std::vector<std::string> names;
+    names.push_back("RF");
+    return names;
 }
 
 double SoapyRFNM::getGain(const int direction, const size_t channel, const std::string &name) const {
     return lrfnm->s->rx.ch[0].gain;
 }
 
-void SoapyRFNM::setGain(const int direction, const size_t channel, const double value) {
+void SoapyRFNM::setGain(const int direction, const size_t channel, const std::string &name, const double value) {
     lrfnm->s->rx.ch[0].gain = value;
     lrfnm->set(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
 }
 
-SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel) const {
+SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel, const std::string &name) const {
     return SoapySDR::Range(-100, 100);
 }
 

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -14,7 +14,7 @@
 #include "librfnm/librfnm.h"
 
 
-#define SOAPY_RFNM_BUFCNF LIBRFNM_MIN_RX_BUFCNT
+#define SOAPY_RFNM_BUFCNT LIBRFNM_MIN_RX_BUFCNT
 
 struct rfnm_soapy_partial_buf {
     uint8_t* buf;
@@ -89,8 +89,8 @@ private:
     int outbufsize;
     int inbufsize;
 
-    struct librfnm_rx_buf rxbuf[SOAPY_RFNM_BUFCNF];
-    struct librfnm_tx_buf txbuf[SOAPY_RFNM_BUFCNF];
+    struct librfnm_rx_buf rxbuf[SOAPY_RFNM_BUFCNT];
+    //struct librfnm_tx_buf txbuf[SOAPY_RFNM_BUFCNT];
 
     struct rfnm_soapy_partial_buf partial_rx_buf;
 };

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -64,14 +64,17 @@ public:
     double getSampleRate(const int direction, const size_t channel) const override;
 
     // Frequency API
+    std::vector<std::string> listFrequencies(const int direction, const size_t channel) const override;
     SoapySDR::RangeList getFrequencyRange(const int direction, const size_t channel, const std::string &name) const override;
     double getFrequency(const int direction, const size_t channel, const std::string &name) const override;
-    void setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args) override;
+    void setFrequency(const int direction, const size_t channel, const std::string &name, const double frequency,
+            const SoapySDR::Kwargs& args) override;
 
     // Gain API
-    SoapySDR::Range getGainRange(const int direction, const size_t channel) const override;
+    std::vector<std::string> listGains(const int direction, const size_t channel) const override;
+    SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const override;
     double getGain(const int direction, const size_t channel, const std::string &name) const override;
-    void setGain(const int direction, const size_t channel, const double value) override;
+    void setGain(const int direction, const size_t channel, const std::string &name, const double value) override;
 
     // Bandwidth API
     SoapySDR::RangeList getBandwidthRange(const int direction, const size_t channel) const override;

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -24,55 +24,64 @@ struct rfnm_soapy_partial_buf {
 
 
 class SoapyRFNM : public SoapySDR::Device {
-    // ctor (rfnm_construction.cpp)
 public:
     explicit SoapyRFNM(const SoapySDR::Kwargs& args);
 
-    ~SoapyRFNM() override;
+    ~SoapyRFNM();
 
-public:
     [[nodiscard]] std::string getDriverKey() const override;
 
     [[nodiscard]] std::string getHardwareKey() const override;
 
     [[nodiscard]] SoapySDR::Kwargs getHardwareInfo() const override;
-public:
 
+    // Stream API
     SoapySDR::Stream* setupStream(const int direction,
         const std::string& format,
         const std::vector<size_t>& channels = std::vector<size_t>(),
-        const SoapySDR::Kwargs& args = SoapySDR::Kwargs());
+        const SoapySDR::Kwargs& args = SoapySDR::Kwargs()) override;
 
-    void closeStream(SoapySDR::Stream* stream);
+    void closeStream(SoapySDR::Stream* stream) override;
 
-    int activateStream(SoapySDR::Stream* stream, const int flags, const long long timeNs, const size_t numElems) override;
+    int activateStream(SoapySDR::Stream* stream, const int flags, const long long timeNs,
+        const size_t numElems) override;
 
     int deactivateStream(SoapySDR::Stream* stream, const int flags0, const long long timeNs) override;
 
-    int readStream(SoapySDR::Stream* stream, void* const* buffs, const size_t numElems, int& flags, long long& timeNs, const long timeoutUs);
+    int readStream(SoapySDR::Stream* stream, void* const* buffs, const size_t numElems, int& flags,
+        long long& timeNs, const long timeoutUs) override;
 
-    size_t getStreamMTU(SoapySDR::Stream* stream) const;
+    size_t getStreamMTU(SoapySDR::Stream* stream) const override;
 
-    size_t getNumChannels(const int direction) const;
+    size_t getNumChannels(const int direction) const override;
 
-    std::vector<double> listSampleRates(const int direction, const size_t channel) const;
+    std::string getNativeStreamFormat(const int direction, const size_t channel, double& fullScale) const override;
 
-    std::string getNativeStreamFormat(const int direction, const size_t channel, double& fullScale) const;
+    std::vector<std::string> getStreamFormats(const int direction, const size_t channel) const override;
 
-    std::vector<std::string> getStreamFormats(const int direction, const size_t channel) const;
+    // Sample Rate API
+    std::vector<double> listSampleRates(const int direction, const size_t channel) const override;
+    double getSampleRate(const int direction, const size_t channel) const override;
 
-    void setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args);
-    void setGain(const int direction, const size_t channel, const double value);
-    SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
+    // Frequency API
+    SoapySDR::RangeList getFrequencyRange(const int direction, const size_t channel, const std::string &name) const override;
+    double getFrequency(const int direction, const size_t channel, const std::string &name) const override;
+    void setFrequency(int direction, size_t channel, double frequency, const SoapySDR::Kwargs& args) override;
 
-    void setBandwidth(const int direction, const size_t channel, const double bw);
+    // Gain API
+    SoapySDR::Range getGainRange(const int direction, const size_t channel) const override;
+    double getGain(const int direction, const size_t channel, const std::string &name) const override;
+    void setGain(const int direction, const size_t channel, const double value) override;
 
-    SoapySDR::RangeList getBandwidthRange(const int direction, const size_t channel) const;
+    // Bandwidth API
+    SoapySDR::RangeList getBandwidthRange(const int direction, const size_t channel) const override;
+    double getBandwidth(const int direction, const size_t channel) const override;
+    void setBandwidth(const int direction, const size_t channel, const double bw) override;
 
-
-    std::vector<std::string> listAntennas(const int direction, const size_t channel) const;
-    void setAntenna(const int direction, const size_t channel, const std::string& name);
-
+    // Antenna API
+    std::vector<std::string> listAntennas(const int direction, const size_t channel) const override;
+    std::string getAntenna(const int direction, const size_t channel) const override;
+    void setAntenna(const int direction, const size_t channel, const std::string& name) override;
 
 private:
     librfnm* lrfnm;


### PR DESCRIPTION
- Implemented various common getter functions used by programs like SigDigger
- Implemented correct methods (with control name) for `setFrequency` and `setGain`
- Fixed various crashes due to use after free and uninitialized variables
- Don't overwrite frequency or path on stream setup
- Fixed compiler warnings
- Cleaned up whitespace and formatting