### PR TITLE
More miscellaneous improvements

### DIFF
--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -82,11 +82,23 @@ size_t SoapyRFNM::getNumChannels(const int direction) const {
 std::vector<double> SoapyRFNM::listSampleRates(const int direction, const size_t channel) const {
     std::vector<double> rates;
     rates.push_back(lrfnm->s->hwinfo.clock.dcs_clk);
+    rates.push_back(lrfnm->s->hwinfo.clock.dcs_clk / 2);
     return rates;
 }
 
 double SoapyRFNM::getSampleRate(const int direction, const size_t channel) const {
-    return lrfnm->s->hwinfo.clock.dcs_clk;
+    return lrfnm->s->hwinfo.clock.dcs_clk / lrfnm->s->rx.ch[0].samp_freq_div_n;
+}
+
+void SoapyRFNM::setSampleRate(const int direction, const size_t channel, const double rate) {
+    if (rate == lrfnm->s->hwinfo.clock.dcs_clk) {
+        lrfnm->s->rx.ch[0].samp_freq_div_n = 1;
+    } else if (rate == lrfnm->s->hwinfo.clock.dcs_clk / 2) {
+        lrfnm->s->rx.ch[0].samp_freq_div_n = 2;
+    } else {
+        throw std::runtime_error("unsupported sample rate");
+    }
+    setRFNM(LIBRFNM_APPLY_CH0_RX /*| LIBRFNM_APPLY_CH0_TX  | LIBRFNM_APPLY_CH1_RX*/);
 }
 
 std::string SoapyRFNM::getNativeStreamFormat(const int direction, const size_t /*channel*/, double& fullScale) const {

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -265,7 +265,7 @@ void SoapyRFNM::closeStream(SoapySDR::Stream* stream) {
 int SoapyRFNM::readStream(SoapySDR::Stream* stream, void* const* buffs, const size_t numElems, int& flags,
         long long int& timeNs, const long timeoutUs) {
     double m_readstream_time_diff;
-
+    uint32_t wait_ms = timeoutUs >= 1000 ? 1 : 0;
     size_t bytes_per_ele = lrfnm->s->transport_status.rx_stream_format;
 
     std::chrono::time_point<std::chrono::system_clock> m_readstream_start_time = std::chrono::system_clock::now();
@@ -287,7 +287,7 @@ keep_waiting:
         partial_rx_buf.offset += can_write_bytes;
     }
 
-    while (read_elems < numElems && !lrfnm->rx_dqbuf(&lrxbuf, LIBRFNM_CH0 /* | LIBRFNM_CH1*/, 0)) {
+    while (read_elems < numElems && !lrfnm->rx_dqbuf(&lrxbuf, LIBRFNM_CH0 /* | LIBRFNM_CH1*/, wait_ms)) {
         size_t overflowing_by_elems = 0;
         size_t can_copy_bytes = outbufsize;
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -153,8 +153,7 @@ void SoapyRFNM::setGain(const int direction, const size_t channel, const std::st
 }
 
 SoapySDR::Range SoapyRFNM::getGainRange(const int direction, const size_t channel, const std::string &name) const {
-    //return SoapySDR::Range(lrfnm->s->rx.ch[0].gain_range.min, lrfnm->s->rx.ch[0].gain_range.max);
-    return SoapySDR::Range(-100, 100);
+    return SoapySDR::Range(lrfnm->s->rx.ch[0].gain_range.min, lrfnm->s->rx.ch[0].gain_range.max);
 }
 
 double SoapyRFNM::getBandwidth(const int direction, const size_t channel) const {

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -310,14 +310,19 @@ keep_waiting:
 
 void SoapyRFNM::setRFNM(uint16_t applies) {
     rfnm_api_failcode ret = lrfnm->set(applies);
+
+    // GCC cannot pass references to values in packed structs, so we need stack copies
+    uint64_t freq = lrfnm->s->rx.ch[0].freq;
+    int8_t gain = lrfnm->s->rx.ch[0].gain;
+
     switch (ret) {
     case RFNM_API_OK:
         return;
     case RFNM_API_TUNE_FAIL:
-        spdlog::error("Failure tuning to {} Hz", lrfnm->s->rx.ch[0].freq);
+        spdlog::error("Failure tuning to {} Hz", freq);
         throw std::runtime_error("Tuning failure");
     case RFNM_API_GAIN_FAIL:
-        spdlog::error("Failure setting gain to {} dB", lrfnm->s->rx.ch[0].gain);
+        spdlog::error("Failure setting gain to {} dB", gain);
         throw std::runtime_error("Gain setting failure");
     case RFNM_API_TIMEOUT:
         spdlog::error("Timeout configuring RFNM");

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -62,6 +62,7 @@ public:
     // Sample Rate API
     std::vector<double> listSampleRates(const int direction, const size_t channel) const override;
     double getSampleRate(const int direction, const size_t channel) const override;
+    void setSampleRate(const int direction, const size_t channel, const double rate) override;
 
     // Frequency API
     std::vector<std::string> listFrequencies(const int direction, const size_t channel) const override;

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -87,6 +87,8 @@ public:
     void setAntenna(const int direction, const size_t channel, const std::string& name) override;
 
 private:
+    void setRFNM(uint16_t applies);
+
     librfnm* lrfnm;
 
     int outbufsize;


### PR DESCRIPTION
- Add support for halving the sample rate
- Avoid busy waits in readStream to reduce CPU usage
- Use the gain range reported by the (new) firmware
- Log and throw exceptions on RFNM configuration failures