### PR TITLE
Channel Info and Channel Settings Support

### DIFF
--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -91,6 +91,24 @@ SoapySDR::Kwargs SoapyRFNM::getHardwareInfo() const {
     return {};
 }
 
+SoapySDR::Kwargs SoapyRFNM::getChannelInfo(const int direction, const size_t channel) const {
+    spdlog::info("RFNMDevice::getChannelInfo()");
+    SoapySDR::Kwargs args;
+    args["name"] = "RB";
+    if (direction == SOAPY_SDR_TX) {
+        args["name"] += (char)('A' + lrfnm->s->tx.ch[channel].dgb_id);
+        args["name"] += "_TX" +
+            std::to_string(lrfnm->s->tx.ch[channel].dgb_ch_id + 1);
+        args["dac_id"] = std::to_string(lrfnm->s->tx.ch[channel].dac_id);
+    } else {
+        args["name"] += (char)('A' + lrfnm->s->rx.ch[channel].dgb_id);
+        args["name"] += "_RX" +
+            std::to_string(lrfnm->s->rx.ch[channel].dgb_ch_id + 1);
+        args["adc_id"] = std::to_string(lrfnm->s->rx.ch[channel].adc_id);
+    }
+    return args;
+}
+
 size_t SoapyRFNM::getStreamMTU(SoapySDR::Stream* stream) const {
     return RFNM_USB_RX_PACKET_ELEM_CNT * 16;
 }

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -100,6 +100,11 @@ public:
     void setDCOffsetMode(const int direction, const size_t channel, const bool automatic) override;
     bool getDCOffsetMode(const int direction, const size_t channel) const override;
 
+    // Channel Settings API
+    SoapySDR::ArgInfoList getSettingInfo(const int direction, const size_t channel) const override;
+    std::string readSetting(const int direction, const size_t channel, const std::string &key) const override;
+    void writeSetting(const int direction, const size_t channel, const std::string &key, const std::string &value) override;
+
 private:
     void setRFNM(uint16_t applies);
 

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -41,6 +41,8 @@ public:
 
     [[nodiscard]] SoapySDR::Kwargs getHardwareInfo() const override;
 
+    SoapySDR::Kwargs getChannelInfo(const int direction, const size_t channel) const override;
+
     // Stream API
     SoapySDR::Stream* setupStream(const int direction,
         const std::string& format,


### PR DESCRIPTION
This PR adds a couple channel info fields that might be helpful in identifying which logical SoapySDR channel ports map to which physical channel, as well as adding control of the bias tee and fm notch filter controls.

Bias tee control has not yet been tested, as I do not have a granita daughterboard installed at the moment and the control is bypassed on present-revision Lime hardware. I may be able to test this later today.

```
% SoapySDRUtil --probe
######################################################
##     Soapy SDR -- the SDR abstraction library     ##
######################################################

Probe device
[2024-06-22 15:15:42.442] [info] rfnm_device_create()
[2024-06-22 15:15:42.442] [info] RFNMDevice::RFNMDevice()
[2024-06-22 15:15:42.452] [info] Max theoretical transport speed is 3500 Mbps
[2024-06-22 15:15:42.457] [info] RFNMDevice::getDriverKey()
[2024-06-22 15:15:42.457] [info] RFNMDevice::getHardwareKey()
[2024-06-22 15:15:42.457] [info] RFNMDevice::getHardwareInfo()
[2024-06-22 15:15:42.457] [info] RFNMDevice::getChannelInfo()
[2024-06-22 15:15:42.457] [info] RFNMDevice::getChannelInfo()

----------------------------------------------------
-- Device identification
----------------------------------------------------
  driver=RFNM
  hardware=RFNM

----------------------------------------------------
-- Peripheral summary
----------------------------------------------------
  Channels: 2 Rx, 0 Tx
  Timestamps: NO

----------------------------------------------------
-- RX Channel 0
----------------------------------------------------
  Channel Information:
    adc_id=0
    name=RBA_RX1
  Full-duplex: NO
  Supports AGC: NO
  Stream formats: CS16, CF32, CS8
  Native format: CS16 [full-scale=32768]
  Antennas: A, embed
  Corrections: DC removal
  Full gain range: [0, 54] dB
    RF gain range: [-24, 30] dB
  Full freq range: [10, 3500] MHz
    RF freq range: [10, 3500] MHz
  Sample rates: 122.88, 61.44 MSps
  Filter bandwidths: [1, 100] MHz
  Other Settings:
     * fm_notch - FM notch filter control
       [key=fm_notch, default=auto, type=string, options=(auto, on, off)]
     * bias_tee_en - Antenna bias tee control
       [key=bias_tee_en, default=false, type=bool]

----------------------------------------------------
-- RX Channel 1
----------------------------------------------------
  Channel Information:
    adc_id=2
    name=RBB_RX1
  Full-duplex: NO
  Supports AGC: NO
  Stream formats: CS16, CF32, CS8
  Native format: CS16 [full-scale=32768]
  Antennas: A, embed
  Corrections: DC removal
  Full gain range: [0, 54] dB
    RF gain range: [-24, 30] dB
  Full freq range: [10, 3500] MHz
    RF freq range: [10, 3500] MHz
  Sample rates: 122.88, 61.44 MSps
  Filter bandwidths: [1, 100] MHz
  Other Settings:
     * fm_notch - FM notch filter control
       [key=fm_notch, default=auto, type=string, options=(auto, on, off)]
     * bias_tee_en - Antenna bias tee control
       [key=bias_tee_en, default=false, type=bool]

[2024-06-22 15:15:42.458] [info] RFNMDevice::~RFNMDevice()
```