### PR TITLE
Report timestamps and fix zero timeout handling with multiple channels

### DIFF
--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -125,6 +125,7 @@ private:
     double phytimer_offset = 0;
     double phytimer_period = 0;
     double phytimer_tick = 0;
+    double next_timestamp = 0;
     uint32_t last_phytimer = 0;
     uint32_t phytimer_ticks_per_sample[MAX_RX_CHAN_COUNT] = {};
 

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -21,6 +21,7 @@ struct rfnm_soapy_partial_buf {
     uint8_t* buf;
     uint32_t left;
     uint32_t offset;
+    uint32_t phytimer;
 };
 
 union rfnm_quad_dc_offset {
@@ -120,6 +121,12 @@ private:
     bool stream_setup = false;
     int outbufsize = 0;
     //int inbufsize = 0;
+
+    double phytimer_offset = 0;
+    double phytimer_period = 0;
+    double phytimer_tick = 0;
+    uint32_t last_phytimer = 0;
+    uint32_t phytimer_ticks_per_sample[MAX_RX_CHAN_COUNT] = {};
 
     struct librfnm_rx_buf rxbuf[SOAPY_RFNM_BUFCNT] = {};
     //struct librfnm_tx_buf txbuf[SOAPY_RFNM_BUFCNT];

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -108,6 +108,9 @@ public:
 private:
     void setRFNM(uint16_t applies);
 
+    rfnm_api_failcode rx_dqbuf_multi(uint32_t wait_for_ms);
+    void rx_qbuf_multi();
+
     size_t rx_chan_count = 0;
     bool dc_correction[MAX_RX_CHAN_COUNT] = {false};
     union rfnm_quad_dc_offset dc_offsets[MAX_RX_CHAN_COUNT] = {};
@@ -122,4 +125,6 @@ private:
     //struct librfnm_tx_buf txbuf[SOAPY_RFNM_BUFCNT];
 
     struct rfnm_soapy_partial_buf partial_rx_buf[MAX_RX_CHAN_COUNT] = {};
+
+    struct librfnm_rx_buf * pending_rx_buf[MAX_RX_CHAN_COUNT] = {};
 };


### PR DESCRIPTION
Previously, with short or zero timeouts, when streaming two channels, channel 0 data would have gaps.