### PR TITLE
Improve timestamp calculation

### DIFF
--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -271,6 +271,14 @@ int SoapyRFNM::activateStream(SoapySDR::Stream* stream, const int flags, const l
         const size_t numElems) {
     spdlog::info("RFNMDevice::activateStream()");
 
+    // workaround stale buffer firmware bug by discarding first few buffers
+    rx_dqbuf_multi(500);
+    rx_qbuf_multi();
+    rx_dqbuf_multi(100);
+    rx_qbuf_multi();
+    rx_dqbuf_multi(50);
+    rx_qbuf_multi();
+
     uint32_t first_phytimer;
     bool first_phytimer_set = false;
 

--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -698,6 +698,7 @@ int SoapyRFNM::readStream(SoapySDR::Stream* stream, void* const* buffs, const si
                 // buffer was lost
                 // TODO: increment by multiple of buf_elems?
                 sample_counter[channel] += samp_delta - buf_elems;
+                spdlog::info("channel {} skip {} samples", channel, samp_delta - buf_elems);
             }
 
             if (!time_set) {

--- a/src/soapy_rfnm.h
+++ b/src/soapy_rfnm.h
@@ -21,7 +21,6 @@ struct rfnm_soapy_partial_buf {
     uint8_t* buf;
     uint32_t left;
     uint32_t offset;
-    uint32_t phytimer;
 };
 
 union rfnm_quad_dc_offset {
@@ -122,11 +121,9 @@ private:
     int outbufsize = 0;
     //int inbufsize = 0;
 
-    double phytimer_offset = 0;
-    double phytimer_period = 0;
-    double phytimer_tick = 0;
-    double next_timestamp = 0;
-    uint32_t last_phytimer = 0;
+    uint64_t sample_counter[MAX_RX_CHAN_COUNT] = {};
+    double ns_per_sample[MAX_RX_CHAN_COUNT] = {};
+    uint32_t last_phytimer[MAX_RX_CHAN_COUNT] = {};
     uint32_t phytimer_ticks_per_sample[MAX_RX_CHAN_COUNT] = {};
 
     struct librfnm_rx_buf rxbuf[SOAPY_RFNM_BUFCNT] = {};


### PR DESCRIPTION
- Keep an integer sample counter rather than a floating point timestamp
- Derive the reported timestamp from the sample counter
- Maintain a steady pace to the timestamps by incrementing the sample counter by the amount of samples read rather than using phytimer values that inherently have jitter
- Tolerate greater amounts of phytimer jitter
- Discard the first three buffers on every channel on stream startup to work around a firmware bug where the phytimer values on the first few received buffers are stale. This bug was causing random timestamp jumps shortly after stream startup.
- Keep independent sample counter indices for each channel to keep track of staggered ADC start times. Note that this logic assumes the time delta from buffer start to dequeue time (phytimer value) is roughly the same for all channels. Later, I plan to use these independent per-channel sample counters to align samples from multiple channels in time domain.