### PR TITLE
Use lower case driver name for registration

### DIFF
--- a/src/soapy_rfnm.cpp
+++ b/src/soapy_rfnm.cpp
@@ -570,4 +570,4 @@ SoapySDR::KwargsList rfnm_device_find(const SoapySDR::Kwargs& args) {
     return ret;
 }
 
-[[maybe_unused]] static SoapySDR::Registry rfnm_module_registration("RFNM", &rfnm_device_find, &rfnm_device_create, SOAPY_SDR_ABI_VERSION);
+[[maybe_unused]] static SoapySDR::Registry rfnm_module_registration("rfnm", &rfnm_device_find, &rfnm_device_create, SOAPY_SDR_ABI_VERSION);


### PR DESCRIPTION
Match the conventions of every other SoapySDR module. A little pain now renaming things specifying the driver, but will save pain in the future if/when more things start hard coding the driver name.